### PR TITLE
Protect against a blank value from NOAA

### DIFF
--- a/noaa/weather/response/CurrentWeather.php
+++ b/noaa/weather/response/CurrentWeather.php
@@ -172,7 +172,7 @@ class CurrentWeather extends Response {
         if (!isset($this->cachedValues[$key])) {
             $path = sprintf("/current_observation/%s[1]", $key);
             $node = $this->xml->xpath($path);
-            $val = (string)$node[0];
+            $val = isset($node[0])? (string)$node[0]: '';
             $this->cachedValues[$key] = $val;
         }
 


### PR DESCRIPTION
If NOAA's XML object doesn't contain a corresponding node for any of the attributes that we query for, an undefined offset notice is generated. To protect against this, we'll default to a blank value and correct for it further down the line.

@amwhalen - I'm not sure if this is how you'd prefer to handle this situation, but I thought I'd offer my solution just in case. Thanks!